### PR TITLE
Added support for extensions section in kubeconfig

### DIFF
--- a/model_kubeconfig.go
+++ b/model_kubeconfig.go
@@ -21,6 +21,7 @@ type KubeConfigClusterParams struct {
 	CertificateAuthority     *string `json:"certificate-authority"`
 	CertificateAuthorityData *string `json:"certificate-authority-data"`
 	InsecureSkipTLSVerify    bool    `json:"insecure-skip-tls-verify"`
+	Extensions               any     `json:"extensions"`
 }
 
 type KubeConfigCluster struct {
@@ -29,9 +30,10 @@ type KubeConfigCluster struct {
 }
 
 type KubeConfigContextParameters struct {
-	Cluster   string `json:"cluster"`
-	User      string `json:"user"`
-	Namespace string `json:"namespace"`
+	Cluster    string `json:"cluster"`
+	User       string `json:"user"`
+	Namespace  string `json:"namespace"`
+	Extensions any    `json:"extensions"`
 }
 
 type KubeConfigContext struct {
@@ -303,6 +305,21 @@ var clusterParamsSchema = schema.NewTypedObject[KubeConfigClusterParams](
 			nil,
 			nil,
 		).TreatEmptyAsDefaultValue(),
+		"extensions": schema.NewPropertySchema(
+			schema.NewAnySchema(),
+			schema.NewDisplayValue(
+				schema.PointerTo("Extensions"),
+				schema.PointerTo("minikube kube config section "+
+					"introduced to avoid local tests issues"),
+				nil,
+			),
+			false,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		),
 	},
 )
 
@@ -384,6 +401,21 @@ var contextParamsSchema = schema.NewTypedObject[KubeConfigContextParameters](
 			nil,
 			nil,
 		).TreatEmptyAsDefaultValue(),
+		"extensions": schema.NewPropertySchema(
+			schema.NewAnySchema(),
+			schema.NewDisplayValue(
+				schema.PointerTo("Extensions"),
+				schema.PointerTo("minikube kube config section "+
+					"introduced to avoid local tests issues"),
+				nil,
+			),
+			false,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		),
 	},
 )
 

--- a/parse_kubeconfig.go
+++ b/parse_kubeconfig.go
@@ -210,7 +210,7 @@ func ConnectionToKubeConfig(connection ConnectionParameters) (KubeConfig, error)
 		Contexts:       []KubeConfigContext{context},
 		Users:          []KubeConfigUser{user},
 		CurrentContext: &defaultStr,
-		Preferences:    map[string]interface{}{}, //default type in sdk parser, used to compare the struct in unit tests
+		Preferences:    map[interface{}]interface{}{}, //default type in sdk parser, used to compare the struct in unit tests
 	}
 
 	return kubeconfig, nil

--- a/parse_kubeconfig_test.go
+++ b/parse_kubeconfig_test.go
@@ -13,15 +13,16 @@ const (
 )
 
 type testFixtures struct {
-	caCert              string
-	clientCrt           string
-	clientKey           string
-	kubeconfig          string
-	kubeconfigNoData    string
-	kubeconfigNoHost    string
-	kubeconfigNoContext string
-	kubeconfigSkipTls   string
-	tokenFile           string
+	caCert               string
+	clientCrt            string
+	clientKey            string
+	kubeconfig           string
+	kubeconfigNoData     string
+	kubeconfigNoHost     string
+	kubeconfigNoContext  string
+	kubeconfigSkipTls    string
+	tokenFile            string
+	kubeconfigExtensions string
 }
 
 func NewFixtures(t *testing.T) testFixtures {
@@ -44,17 +45,20 @@ func NewFixtures(t *testing.T) testFixtures {
 	assert.Nil(t, err)
 	tokenFile, err := os.ReadFile("testdata/tokenfile")
 	assert.Nil(t, err)
+	kubeExtensions, err := os.ReadFile("testdata/kubeconfig-extensions.yaml")
+	assert.Nil(t, err)
 
 	return testFixtures{
-		caCert:              string(caCrt),
-		clientCrt:           string(clientCrt),
-		clientKey:           string(clientKey),
-		kubeconfig:          string(kube),
-		kubeconfigNoData:    string(kubeNodata),
-		kubeconfigNoHost:    string(kubeNoHost),
-		kubeconfigNoContext: string(kubeNoCtx),
-		kubeconfigSkipTls:   string(kubeTlsSkip),
-		tokenFile:           string(tokenFile),
+		caCert:               string(caCrt),
+		clientCrt:            string(clientCrt),
+		clientKey:            string(clientKey),
+		kubeconfig:           string(kube),
+		kubeconfigNoData:     string(kubeNodata),
+		kubeconfigNoHost:     string(kubeNoHost),
+		kubeconfigNoContext:  string(kubeNoCtx),
+		kubeconfigSkipTls:    string(kubeTlsSkip),
+		tokenFile:            string(tokenFile),
+		kubeconfigExtensions: string(kubeExtensions),
 	}
 }
 
@@ -63,6 +67,10 @@ func TestParseKubeConfig(t *testing.T) {
 	kubeconf, err := ParseKubeConfig(fixtures.kubeconfig)
 	assert.Nil(t, err)
 	assert.NotNil(t, kubeconf)
+
+	kubeconfExtensions, err := ParseKubeConfig(fixtures.kubeconfigExtensions)
+	assert.Nil(t, err)
+	assert.NotNil(t, kubeconfExtensions)
 }
 
 func TestKubeConfigToConnection(t *testing.T) {

--- a/testdata/kubeconfig-extensions.yaml
+++ b/testdata/kubeconfig-extensions.yaml
@@ -3,12 +3,22 @@ clusters:
   - cluster:
       certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM5ekNDQWQrZ0F3SUJBZ0lVV01PTVBNMVUrRi9uNXN6TSthYzlMcGZISHB3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd0hqRWNNQm9HQTFVRUF3d1RhM1ZpZFc1MGRTNXNiMk5oYkdSdmJXRnBiakFlRncweU1URXlNRFl4T0RBdwpNRFJhRncwek1URXlNRFF4T0RBd01EUmFNQjR4SERBYUJnTlZCQU1NRTJ0MVluVnVkSFV1Ykc5allXeGtiMjFoCmFXNHdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDNExhcG00SDB0T1NuYTNXVisKdzI4a0tOWWRwaHhYOUtvNjUwVGlOK2c5ZFNQU3VZK0V6T1JVOWVONlgyWUZkMEJmVFNodno4Y25rclAvNysxegpETEoxQ3MwRi9haEV3ZDQxQXN5UGFjbnRiVE80dGRLWm9POUdyODR3YVdBN1hSZmtEc2ZxRGN1YW5UTmVmT1hpCkdGbmdDVzU5Q285M056alB1eEFrakJxdVF6eE5GQkgwRlJPbXJtVFJ4cnVLZXo0aFFuUW1OWEFUNnp0M21udzMKWUtWTzU4b2xlcUxUcjVHNlRtVFQyYTZpVGdtdWY2N0cvaVZlalJGbkw3YkNHWmgzSjlCSTNMcVpqRzE4dWxvbgpaVDdQcGQrQTlnaTJOTm9UZlI2TVB5SndxU1BCL0xZQU5ZNGRoZDVJYlVydDZzbmViTlRZSHV2T0tZTDdNTWRMCmVMSzFBZ01CQUFHakxUQXJNQWtHQTFVZEV3UUNNQUF3SGdZRFZSMFJCQmN3RllJVGEzVmlkVzUwZFM1c2IyTmgKYkdSdmJXRnBiakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQTVqUHVpZVlnMExySE1PSkxYY0N4d3EvVzBDNApZeFpncVd3VHF5VHNCZjVKdDlhYTk0SkZTc2dHQWdzUTN3NnA2SlBtL0MyR05MY3U4ZWxjV0E4UXViQWxueXRRCnF1cEh5WnYrZ08wMG83TXdrejZrTUxqQVZ0QllkRzJnZ21FRjViTEk5czBKSEhjUGpHUkl1VHV0Z0tHV1dPWHgKSEg4T0RzaG9wZHRXMktrR2c2aThKaEpYaWVIbzkzTHptM00xRUNGcXAvMEdtNkN1RFphVVA2SGpJMWRrYllLdgpsSHNVZ1U1SmZjSWhNYmJLdUllTzRkc1YvT3FHcm9iNW5vcmRjaExBQmRDTnc1cmU5T1NXZGZ1VVhSK0ViZVhrCjVFM0tFYzA1RGNjcGV2a1NTdlJ4SVQrQzNMOTltWGcxL3B5NEw3VUhvNFFLTXlqWXJXTWlLRlVKV1E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
       server: https://127.0.0.1:6443
+      extensions:
+        - extension:
+            last-update: Tue, 04 Apr 2023 09:57:14 CEST
+            provider: minikube.sigs.k8s.io
+            version: v1.29.0
     name: default
 contexts:
   - context:
       cluster: default
       namespace: default
       user: testuser
+      extensions:
+        - extension:
+            last-update: Tue, 04 Apr 2023 09:57:14 CEST
+            provider: minikube.sigs.k8s.io
+            version: v1.29.0
     name: default
 current-context: default
 kind: Config
@@ -21,4 +31,5 @@ users:
       username: testuser
       password: testpassword
       token: sha256~fFyEqjf1xxFMO0tbEyGRvWeNOd7QByuEgS4hyEq_A9o
+
 


### PR DESCRIPTION
## Changes introduced with this PR
Minikube frequently adds an extensions section to the kube config that creates issues with local testing. This change introduces the support of this section as any type .

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).